### PR TITLE
adding publish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "test": "jest",
     "test:flow": "flow"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jest": {
     "setupFiles": [
       "./scripts/test-setup"


### PR DESCRIPTION
We were going to publish and realized this wasn't in here yet. Since this is a scoped package, I _think_ we need `--access public` for yarn publish 🤔.